### PR TITLE
Now ebean packages list could contain multiple elements ([models.*,co…

### DIFF
--- a/play2-maven-plugin/src/main/java/com/google/code/play2/plugin/Play2EbeanEnhanceMojo.java
+++ b/play2-maven-plugin/src/main/java/com/google/code/play2/plugin/Play2EbeanEnhanceMojo.java
@@ -20,24 +20,15 @@ package com.google.code.play2.plugin;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
+import com.typesafe.config.*;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigException;
-import com.typesafe.config.ConfigFactory;
-import com.typesafe.config.ConfigValue;
 
 import com.google.code.play2.provider.api.Play2EbeanEnhancer;
 import com.google.code.play2.provider.api.Play2Provider;
@@ -65,47 +56,8 @@ public class Play2EbeanEnhanceMojo
     protected void internalExecute()
         throws MojoExecutionException, MojoFailureException, IOException
     {
-        Config config = null;
-        String configResource = System.getProperty( "config.resource" );
-        if ( configResource != null )
-        {
-            config = ConfigFactory.parseResources( configResource );
-        }
-        else
-        {
-            String configFileName = System.getProperty( "config.file", "conf/application.conf" );
-            File applicationConfFile = new File( project.getBasedir(), configFileName );
-            config = ConfigFactory.parseFileAnySyntax( applicationConfFile );
-        }
-
-        String models;
-        try
-        {
-            Set<Map.Entry<String, ConfigValue>> entries = config.getConfig( "ebean" ).resolve().entrySet();
-
-            StringBuilder modelsCollector = new StringBuilder();
-            for ( Map.Entry<String, ConfigValue> entry : entries )
-            {
-                Object configValueUnwrapped = entry.getValue().unwrapped();
-
-                Collection itemsToEnhance = ( configValueUnwrapped instanceof Collection ) ?
-                        (Collection) configValueUnwrapped : Collections.singleton( configValueUnwrapped );
-
-                for( Object itemToEnhance : itemsToEnhance )
-                {
-                    if ( modelsCollector.length() != 0 )
-                    {
-                        modelsCollector.append( ',' );
-                    }
-                    modelsCollector.append( itemToEnhance.toString() );
-                }
-            }
-            models = modelsCollector.toString();
-        }
-        catch ( ConfigException.Missing e )
-        {
-            models = "models.*";
-        }
+        Config config = getPlayConfiguration().resolve();
+        String models  = getEBeanModelsToEnhance( config );
 
         File outputDirectory = new File( project.getBuild().getOutputDirectory() );
 
@@ -201,6 +153,49 @@ public class Play2EbeanEnhanceMojo
         else
         {
             getLog().info( "No Ebean classes to enhance" );
+        }
+    }
+
+    private Config getPlayConfiguration() {
+        String configResource = System.getProperty( "config.resource" );
+        if ( configResource != null )
+        {
+            return ConfigFactory.parseResources( configResource );
+        } else
+        {
+            String configFileName = System.getProperty( "config.file", "conf/application.conf" );
+            File applicationConfFile = new File( project.getBasedir(), configFileName );
+            return ConfigFactory.parseFileAnySyntax( applicationConfFile );
+        }
+    }
+
+    private String getEBeanModelsToEnhance(Config config)
+    {
+        try
+        {
+            StringBuilder collector = new StringBuilder();
+
+            Set<Map.Entry<String, ConfigValue>> entries = config.getConfig( "ebean" ).entrySet();
+            for ( Map.Entry<String, ConfigValue> entry : entries )
+            {
+                ConfigValue configValue = entry.getValue();
+                if ( configValue.valueType() == ConfigValueType.STRING )
+                {
+                    collector.append( ',' ).append( configValue.unwrapped().toString() );
+                } else
+                {
+                    String configKey = "ebean." + entry.getKey();
+                    List<String> tmpModels = config.getStringList( configKey );
+                    for ( String tmpModel : tmpModels )
+                    {
+                        collector.append( ',' ).append( tmpModel );
+                    }
+                }
+            }
+            return collector.length() != 0 ? collector.substring( 1 ) : null;
+        } catch ( ConfigException.Missing e )
+        {
+            return "models.*";
         }
     }
 


### PR DESCRIPTION
Fixed issue with ebean models definition parsing for expressions which creates ConfigList:

- ebean.default = ["models.*"]
- ebean.default = ["models.Order", "models.OrderItem"]
- ebean.default += "models.*"