### PR TITLE
#150 - Align Maven implementation of Ebean configuration reading with SBT

### DIFF
--- a/play2-maven-plugin/pom.xml
+++ b/play2-maven-plugin/pom.xml
@@ -74,12 +74,6 @@ under the License.
             <version>${ant.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.typesafe</groupId>
-            <artifactId>config</artifactId>
-            <version>1.3.1</version> <!-- binary compatible with 1.0.x -->
-        </dependency>
-
         <!-- Maven -->
 
         <dependency>

--- a/play2-provider-api/src/main/java/com/google/code/play2/provider/api/Play2EbeanEnhancer.java
+++ b/play2-provider-api/src/main/java/com/google/code/play2/provider/api/Play2EbeanEnhancer.java
@@ -27,6 +27,8 @@ public interface Play2EbeanEnhancer
 
     void setClassPathUrls( List<URL> classPathUrls ); /* change the name? */
 
+    String getModelsToEnhance();
+
     boolean enhanceModel( File classFile )
         throws Exception;
 

--- a/play2-providers/play2-provider-play21/pom.xml
+++ b/play2-providers/play2-provider-play21/pom.xml
@@ -95,6 +95,12 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>play</groupId>
             <artifactId>routes-compiler_2.9.2</artifactId>
             <version>${play2.version}</version>

--- a/play2-providers/play2-provider-play22/pom.xml
+++ b/play2-providers/play2-provider-play22/pom.xml
@@ -75,6 +75,12 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.typesafe.play</groupId>
             <artifactId>routes-compiler_2.10</artifactId>
             <version>${play2.version}</version>

--- a/play2-providers/play2-provider-play22/src/main/java/com/google/code/play2/provider/play22/Play22EbeanEnhancer.java
+++ b/play2-providers/play2-provider-play22/src/main/java/com/google/code/play2/provider/play22/Play22EbeanEnhancer.java
@@ -19,11 +19,20 @@ package com.google.code.play2.provider.play22;
 
 import java.io.File;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import com.avaje.ebean.enhance.agent.InputStreamTransform;
 import com.avaje.ebean.enhance.agent.Transformer;
 import com.avaje.ebean.enhance.ant.StringReplace;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigParseOptions;
+import com.typesafe.config.ConfigValue;
 
 import com.google.code.play2.provider.api.Play2EbeanEnhancer;
 
@@ -31,6 +40,8 @@ public class Play22EbeanEnhancer
     implements Play2EbeanEnhancer
 {
     private File outputDirectory;
+
+    private List<URL> classPathUrls;
 
     private InputStreamTransform inputStreamTransform;
 
@@ -43,10 +54,53 @@ public class Play22EbeanEnhancer
     @Override
     public void setClassPathUrls( List<URL> classPathUrls )
     {
+        this.classPathUrls = classPathUrls;
+
         URL[] cp = classPathUrls.toArray( new URL[classPathUrls.size()] );
         ClassLoader classLoader = ClassLoader.getSystemClassLoader();
         Transformer transformer = new Transformer( cp, "debug=-1" );
-        inputStreamTransform = new InputStreamTransform( transformer, classLoader );
+        this.inputStreamTransform = new InputStreamTransform( transformer, classLoader );
+    }
+
+    @Override
+    public String getModelsToEnhance() //TODO - change to collection of strings
+    {
+        Config config = getConfig();
+        try
+        {
+            StringBuilder collector = new StringBuilder();
+
+            Set<Map.Entry<String, ConfigValue>> entries = config.getConfig( "ebean" ).entrySet();
+            for ( Map.Entry<String, ConfigValue> entry : entries )
+            {
+                ConfigValue configValue = entry.getValue();
+                collector.append( ',' ).append( configValue.unwrapped().toString() );
+            }
+            return collector.length() != 0 ? collector.substring( 1 ) : null;
+        }
+        catch ( ConfigException.Missing e )
+        {
+            return "models.*";
+        }
+    }
+
+    private Config getConfig()
+    {
+        String configResource = System.getProperty( "config.resource" );
+        if ( configResource != null )
+        {
+            URL[] cp = classPathUrls.toArray( new URL[classPathUrls.size()] );
+            URLClassLoader classLoader = new URLClassLoader( cp, null );
+            ConfigParseOptions options = ConfigParseOptions.defaults().setClassLoader( classLoader );
+            return ConfigFactory.parseResources( configResource, options );
+        }
+        String configFileName = System.getProperty( "config.file" );
+        if ( configFileName != null )
+        {
+            return ConfigFactory.parseFileAnySyntax( new File( configFileName ) );
+        }
+        // in 'process-classes' phase resources are already copied to the output directory
+        return ConfigFactory.parseFileAnySyntax( new File( outputDirectory, "application.conf" ) );
     }
 
     @Override
@@ -54,7 +108,7 @@ public class Play22EbeanEnhancer
         throws Exception
     {
         boolean processed = false;
-        
+
         String className = getClassName( classFile );
         byte[] result = inputStreamTransform.transform( className, classFile );
         if ( result != null )

--- a/play2-providers/play2-provider-play23/pom.xml
+++ b/play2-providers/play2-provider-play23/pom.xml
@@ -65,6 +65,12 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.typesafe.play</groupId>
             <artifactId>routes-compiler_2.10</artifactId>
             <version>${play2.version}</version>

--- a/play2-providers/play2-provider-play23/src/main/java/com/google/code/play2/provider/play23/Play23EbeanEnhancer.java
+++ b/play2-providers/play2-provider-play23/src/main/java/com/google/code/play2/provider/play23/Play23EbeanEnhancer.java
@@ -19,18 +19,29 @@ package com.google.code.play2.provider.play23;
 
 import java.io.File;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.List;
-
-import com.google.code.play2.provider.api.Play2EbeanEnhancer;
+import java.util.Map;
+import java.util.Set;
 
 import com.avaje.ebean.enhance.agent.InputStreamTransform;
 import com.avaje.ebean.enhance.agent.Transformer;
 import com.avaje.ebean.enhance.ant.StringReplace;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigParseOptions;
+import com.typesafe.config.ConfigValue;
+
+import com.google.code.play2.provider.api.Play2EbeanEnhancer;
+
 public class Play23EbeanEnhancer
     implements Play2EbeanEnhancer
 {
     private File outputDirectory;
+
+    private List<URL> classPathUrls;
 
     private InputStreamTransform inputStreamTransform;
 
@@ -43,10 +54,53 @@ public class Play23EbeanEnhancer
     @Override
     public void setClassPathUrls( List<URL> classPathUrls )
     {
+        this.classPathUrls = classPathUrls;
+
         URL[] cp = classPathUrls.toArray( new URL[classPathUrls.size()] );
         ClassLoader classLoader = ClassLoader.getSystemClassLoader();
         Transformer transformer = new Transformer( cp, "debug=-1" );
-        inputStreamTransform = new InputStreamTransform( transformer, classLoader );
+        this.inputStreamTransform = new InputStreamTransform( transformer, classLoader );
+    }
+
+    @Override
+    public String getModelsToEnhance()
+    {
+        Config config = getConfig();
+        try
+        {
+            StringBuilder collector = new StringBuilder();
+
+            Set<Map.Entry<String, ConfigValue>> entries = config.getConfig( "ebean" ).entrySet();
+            for ( Map.Entry<String, ConfigValue> entry : entries )
+            {
+                ConfigValue configValue = entry.getValue();
+                collector.append( ',' ).append( configValue.unwrapped().toString() );
+            }
+            return collector.length() != 0 ? collector.substring( 1 ) : null;
+        }
+        catch ( ConfigException.Missing e )
+        {
+            return "models.*";
+        }
+    }
+
+    private Config getConfig()
+    {
+        String configResource = System.getProperty( "config.resource" );
+        if ( configResource != null )
+        {
+            URL[] cp = classPathUrls.toArray( new URL[classPathUrls.size()] );
+            URLClassLoader classLoader = new URLClassLoader( cp, null );
+            ConfigParseOptions options = ConfigParseOptions.defaults().setClassLoader( classLoader );
+            return ConfigFactory.parseResources( configResource, options );
+        }
+        String configFileName = System.getProperty( "config.file" );
+        if ( configFileName != null )
+        {
+            return ConfigFactory.parseFileAnySyntax( new File( configFileName ) );
+        }
+        // in 'process-classes' phase resources are already copied to the output directory
+        return ConfigFactory.parseFileAnySyntax( new File( outputDirectory, "application.conf" ) );
     }
 
     @Override
@@ -54,7 +108,7 @@ public class Play23EbeanEnhancer
         throws Exception
     {
         boolean processed = false;
-        
+
         String className = getClassName( classFile );
         byte[] result = inputStreamTransform.transform( className, classFile );
         if ( result != null )

--- a/play2-providers/play2-provider-play24/pom.xml
+++ b/play2-providers/play2-provider-play24/pom.xml
@@ -115,8 +115,21 @@ under the License.
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
+                        <source>1.8</source>
+                        <links>
+                            <link>https://docs.oracle.com/javase/8/docs/api/</link>
+                        </links>
                         <sourcepath>${project.basedir}/src/main/java:${project.basedir}/../../play2-provider-api/src/main/java</sourcepath>
                         <subpackages>com.google.code.play2.provider.play24</subpackages>
                     </configuration>
@@ -139,6 +152,19 @@ under the License.
                         <excludes>
                             <exclude>play/runsupport/classloader/*</exclude>
                         </excludes>
+                        <targetJdk>1.8</targetJdk>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <configuration>
+                        <signature>
+                            <groupId>org.codehaus.mojo.signature</groupId>
+                            <artifactId>java18</artifactId>
+                            <version>1.0</version>
+                        </signature>
                     </configuration>
                 </plugin>
 
@@ -171,6 +197,26 @@ under the License.
                 </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-java</id>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>1.8</version>
+                                    <message>Java 1.8 or later required.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/play2-providers/play2-provider-play24/src/main/java/com/google/code/play2/provider/play24/Play24EbeanEnhancer.java
+++ b/play2-providers/play2-provider-play24/src/main/java/com/google/code/play2/provider/play24/Play24EbeanEnhancer.java
@@ -18,20 +18,28 @@
 package com.google.code.play2.provider.play24;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.List;
-
-import com.google.code.play2.provider.api.Play2EbeanEnhancer;
+import java.util.Map;
+import java.util.function.Function;
 
 import com.avaje.ebean.enhance.agent.InputStreamTransform;
 import com.avaje.ebean.enhance.agent.Transformer;
 import com.avaje.ebean.enhance.ant.StringReplace;
 
+import com.google.code.play2.provider.api.Play2EbeanEnhancer;
+
 public class Play24EbeanEnhancer
     implements Play2EbeanEnhancer
 {
+    private static final String configLoaderClassName = "play.db.ebean.ModelsConfigLoader";
+
     private File outputDirectory;
+
+    private List<URL> classPathUrls;
 
     private InputStreamTransform inputStreamTransform;
 
@@ -44,10 +52,75 @@ public class Play24EbeanEnhancer
     @Override
     public void setClassPathUrls( List<URL> classPathUrls )
     {
+        this.classPathUrls = classPathUrls;
+
         URL[] cp = classPathUrls.toArray( new URL[classPathUrls.size()] );
         ClassLoader classLoader = new URLClassLoader( cp, null );
         Transformer transformer = new Transformer( cp, "debug=-1" );
-        inputStreamTransform = new InputStreamTransform( transformer, classLoader );
+        this.inputStreamTransform = new InputStreamTransform( transformer, classLoader );
+    }
+
+    @Override
+    public String getModelsToEnhance()
+    {
+        Map<String, List<String>> config = getConfig();
+
+        if ( !config.isEmpty() )
+        {
+            List<String> result = new ArrayList<String>();
+            for ( List<String> modelsList: config.values() )
+            {
+                for ( String models: modelsList )
+                {
+                    if ( !result.contains( models ) )
+                    {
+                        result.add( models );
+                    }
+                }
+            }
+            return String.join( ",", result );
+        }
+        return  "models.*";
+    }
+
+    private Map<String, List<String>> getConfig()
+    {
+        URL[] cp = classPathUrls.toArray( new URL[classPathUrls.size()] );
+        URLClassLoader classLoader = new URLClassLoader( cp, null );
+        try
+        {
+            Class<?> configLoaderClass = classLoader.loadClass( configLoaderClassName );
+            Function<ClassLoader, Map<String, List<String>>> configLoader =
+                    ( Function<ClassLoader, Map<String, List<String>>> ) configLoaderClass.newInstance();
+
+            return configLoader.apply( classLoader );
+        }
+        catch ( ClassNotFoundException | IllegalAccessException | InstantiationException e )
+        {
+            throw cloneException( e );
+        }
+        finally
+        {
+            try
+            {
+                classLoader.close();
+            }
+            catch ( IOException e )
+            {
+                // ignore
+            }
+        }
+    }
+
+    private RuntimeException cloneException( Throwable t )
+    {
+        RuntimeException cloned = new RuntimeException( t.getClass().getName() + ": " + t.getMessage() );
+        cloned.setStackTrace( t.getStackTrace() );
+        if ( t.getCause() != null )
+        {
+            cloned.initCause( cloneException( t.getCause() ) );
+        }
+        return cloned;
     }
 
     @Override
@@ -55,7 +128,7 @@ public class Play24EbeanEnhancer
         throws Exception
     {
         boolean processed = false;
-        
+
         String className = getClassName( classFile );
         byte[] result = inputStreamTransform.transform( className, classFile );
         if ( result != null )

--- a/play2-providers/play2-provider-play25/pom.xml
+++ b/play2-providers/play2-provider-play25/pom.xml
@@ -115,8 +115,21 @@ under the License.
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
+                        <source>1.8</source>
+                        <links>
+                            <link>https://docs.oracle.com/javase/8/docs/api/</link>
+                        </links>
                         <sourcepath>${project.basedir}/src/main/java:${project.basedir}/../../play2-provider-api/src/main/java</sourcepath>
                         <subpackages>com.google.code.play2.provider.play25</subpackages>
                     </configuration>
@@ -139,6 +152,19 @@ under the License.
                         <excludes>
                             <exclude>play/runsupport/classloader/*</exclude>
                         </excludes>
+                        <targetJdk>1.8</targetJdk>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <configuration>
+                        <signature>
+                            <groupId>org.codehaus.mojo.signature</groupId>
+                            <artifactId>java18</artifactId>
+                            <version>1.0</version>
+                        </signature>
                     </configuration>
                 </plugin>
 
@@ -171,6 +197,26 @@ under the License.
                 </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-java</id>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>1.8</version>
+                                    <message>Java 1.8 or later required.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/play2-providers/play2-provider-play25/src/main/java/com/google/code/play2/provider/play25/Play25EbeanEnhancer.java
+++ b/play2-providers/play2-provider-play25/src/main/java/com/google/code/play2/provider/play25/Play25EbeanEnhancer.java
@@ -18,20 +18,28 @@
 package com.google.code.play2.provider.play25;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.List;
-
-import com.google.code.play2.provider.api.Play2EbeanEnhancer;
+import java.util.Map;
+import java.util.function.Function;
 
 import com.avaje.ebean.enhance.agent.InputStreamTransform;
 import com.avaje.ebean.enhance.agent.Transformer;
 import com.avaje.ebean.enhance.ant.StringReplace;
 
+import com.google.code.play2.provider.api.Play2EbeanEnhancer;
+
 public class Play25EbeanEnhancer
     implements Play2EbeanEnhancer
 {
+    private static final String configLoaderClassName = "play.db.ebean.ModelsConfigLoader";
+
     private File outputDirectory;
+
+    private List<URL> classPathUrls;
 
     private InputStreamTransform inputStreamTransform;
 
@@ -44,10 +52,75 @@ public class Play25EbeanEnhancer
     @Override
     public void setClassPathUrls( List<URL> classPathUrls )
     {
+        this.classPathUrls = classPathUrls;
+
         URL[] cp = classPathUrls.toArray( new URL[classPathUrls.size()] );
         ClassLoader classLoader = new URLClassLoader( cp, null );
         Transformer transformer = new Transformer( cp, "debug=-1" );
-        inputStreamTransform = new InputStreamTransform( transformer, classLoader );
+        this.inputStreamTransform = new InputStreamTransform( transformer, classLoader );
+    }
+
+    @Override
+    public String getModelsToEnhance()
+    {
+        Map<String, List<String>> config = getConfig();
+
+        if ( !config.isEmpty() )
+        {
+            List<String> result = new ArrayList<String>();
+            for ( List<String> modelsList: config.values() )
+            {
+                for ( String models: modelsList )
+                {
+                    if ( !result.contains( models ) )
+                    {
+                        result.add( models );
+                    }
+                }
+            }
+            return String.join( ",", result );
+        }
+        return  "models.*";
+    }
+
+    private Map<String, List<String>> getConfig()
+    {
+        URL[] cp = classPathUrls.toArray( new URL[classPathUrls.size()] );
+        URLClassLoader classLoader = new URLClassLoader( cp, null );
+        try
+        {
+            Class<?> configLoaderClass = classLoader.loadClass( configLoaderClassName );
+            Function<ClassLoader, Map<String, List<String>>> configLoader =
+                    ( Function<ClassLoader, Map<String, List<String>>> ) configLoaderClass.newInstance();
+
+            return configLoader.apply( classLoader );
+        }
+        catch ( ClassNotFoundException | IllegalAccessException | InstantiationException e )
+        {
+            throw cloneException( e );
+        }
+        finally
+        {
+            try
+            {
+                classLoader.close();
+            }
+            catch ( IOException e )
+            {
+                // ignore
+            }
+        }
+    }
+
+    private RuntimeException cloneException( Throwable t )
+    {
+        RuntimeException cloned = new RuntimeException( t.getClass().getName() + ": " + t.getMessage() );
+        cloned.setStackTrace( t.getStackTrace() );
+        if ( t.getCause() != null )
+        {
+            cloned.initCause( cloneException( t.getCause() ) );
+        }
+        return cloned;
     }
 
     @Override
@@ -55,7 +128,7 @@ public class Play25EbeanEnhancer
         throws Exception
     {
         boolean processed = false;
-        
+
         String className = getClassName( classFile );
         byte[] result = inputStreamTransform.transform( className, classFile );
         if ( result != null )

--- a/play2-providers/play2-provider-play26/pom.xml
+++ b/play2-providers/play2-provider-play26/pom.xml
@@ -115,8 +115,21 @@ under the License.
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
+                        <source>1.8</source>
+                        <links>
+                            <link>https://docs.oracle.com/javase/8/docs/api/</link>
+                        </links>
                         <sourcepath>${project.basedir}/src/main/java:${project.basedir}/../../play2-provider-api/src/main/java</sourcepath>
                         <subpackages>com.google.code.play2.provider.play26</subpackages>
                     </configuration>
@@ -139,6 +152,19 @@ under the License.
                         <excludes>
                             <exclude>play/runsupport/classloader/*</exclude>
                         </excludes>
+                        <targetJdk>1.8</targetJdk>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <configuration>
+                        <signature>
+                            <groupId>org.codehaus.mojo.signature</groupId>
+                            <artifactId>java18</artifactId>
+                            <version>1.0</version>
+                        </signature>
                     </configuration>
                 </plugin>
 
@@ -171,6 +197,26 @@ under the License.
                 </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-java</id>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>1.8</version>
+                                    <message>Java 1.8 or later required.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/play2-providers/play2-provider-play26/src/main/java/com/google/code/play2/provider/play26/Play26EbeanEnhancer.java
+++ b/play2-providers/play2-provider-play26/src/main/java/com/google/code/play2/provider/play26/Play26EbeanEnhancer.java
@@ -18,20 +18,28 @@
 package com.google.code.play2.provider.play26;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.List;
-
-import com.google.code.play2.provider.api.Play2EbeanEnhancer;
+import java.util.Map;
+import java.util.function.Function;
 
 import io.ebean.enhance.Transformer;
 import io.ebean.enhance.ant.StringReplace;
 import io.ebean.enhance.common.InputStreamTransform;
 
+import com.google.code.play2.provider.api.Play2EbeanEnhancer;
+
 public class Play26EbeanEnhancer
     implements Play2EbeanEnhancer
 {
+    private static final String configLoaderClassName = "play.db.ebean.ModelsConfigLoader";
+
     private File outputDirectory;
+
+    private List<URL> classPathUrls;
 
     private InputStreamTransform inputStreamTransform;
 
@@ -44,10 +52,75 @@ public class Play26EbeanEnhancer
     @Override
     public void setClassPathUrls( List<URL> classPathUrls )
     {
+        this.classPathUrls = classPathUrls;
+
         URL[] cp = classPathUrls.toArray( new URL[classPathUrls.size()] );
         ClassLoader classLoader = new URLClassLoader( cp, null );
         Transformer transformer = new Transformer( classLoader, "debug=-1" );
-        inputStreamTransform = new InputStreamTransform( transformer, classLoader );
+        this.inputStreamTransform = new InputStreamTransform( transformer, classLoader );
+    }
+
+    @Override
+    public String getModelsToEnhance()
+    {
+        Map<String, List<String>> config = getConfig();
+
+        if ( !config.isEmpty() )
+        {
+            List<String> result = new ArrayList<String>();
+            for ( List<String> modelsList: config.values() )
+            {
+                for ( String models: modelsList )
+                {
+                    if ( !result.contains( models ) )
+                    {
+                        result.add( models );
+                    }
+                }
+            }
+            return String.join( ",", result );
+        }
+        return  "models.*";
+    }
+
+    private Map<String, List<String>> getConfig()
+    {
+        URL[] cp = classPathUrls.toArray( new URL[classPathUrls.size()] );
+        URLClassLoader classLoader = new URLClassLoader( cp, null );
+        try
+        {
+            Class<?> configLoaderClass = classLoader.loadClass( configLoaderClassName );
+            Function<ClassLoader, Map<String, List<String>>> configLoader =
+                    ( Function<ClassLoader, Map<String, List<String>>> ) configLoaderClass.newInstance();
+
+            return configLoader.apply( classLoader );
+        }
+        catch ( ClassNotFoundException | IllegalAccessException | InstantiationException e )
+        {
+            throw cloneException( e );
+        }
+        finally
+        {
+            try
+            {
+                classLoader.close();
+            }
+            catch ( IOException e )
+            {
+                // ignore
+            }
+        }
+    }
+
+    private RuntimeException cloneException( Throwable t )
+    {
+        RuntimeException cloned = new RuntimeException( t.getClass().getName() + ": " + t.getMessage() );
+        cloned.setStackTrace( t.getStackTrace() );
+        if ( t.getCause() != null )
+        {
+            cloned.initCause( cloneException( t.getCause() ) );
+        }
+        return cloned;
     }
 
     @Override


### PR DESCRIPTION
The implementation of configuration reading for Ebean models enhancement in Play! Framework changed (improved) from version to version.
This plugin supports all Play! versions starting from 2.1.x and should behave similarly to SBT behaviour for every version.

Original (SBT plugin) code:

- [Play! 2.1.x](https://github.com/playframework/playframework/blob/2.1.5/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala#L355-L359)
```scala
        val config = ConfigFactory.load(ConfigFactory.parseFileAnySyntax(new File("conf/application.conf")))

        val models = try {
          config.getConfig("ebean").entrySet.asScala.map(_.getValue.unwrapped).toSet.mkString(",")
        } catch { case e: ConfigException.Missing => "models.*" }
```
- [Play! 2.2.x](https://github.com/playframework/playframework/blob/2.2.6/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala#L150-L159) and [Play! 2.3.x](https://github.com/playframework/playframework/blob/2.3.10/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala#L130-L139)
```scala
lazy val file = {
          Option(System.getProperty("config.file")).map(f => new File(f)).getOrElse(new File("conf/application.conf"))
        }

        val config = Option(System.getProperty("config.resource"))
          .map(ConfigFactory.parseResources(_)).getOrElse(ConfigFactory.parseFileAnySyntax(file))

        val models = try {
          config.getConfig("ebean").entrySet.asScala.map(_.getValue.unwrapped).toSet.mkString(",")
        } catch { case e: ConfigException.Missing => "models.*" }
```

In version 2.4.0 Ebean support was extracted to a separate [Play Ebean Plugin](https://github.com/playframework/play-ebean). Ebean Configuration reading code was changed significantly. Configuration processing is delegated from plugin to project's `play-ebean` dependency (using project's classpath).

Original (Play-Ebean SBT plugin) code:
- [play-ebean 1.0.0](https://github.com/playframework/play-ebean/blob/1.0.0/sbt-play-ebean/src/main/scala/play/ebean/sbt/PlayEbean.scala#L107-L148) used by [play-java-ebean-example branch 2.4.x](https://github.com/playframework/play-java-ebean-example/tree/2.4.x)
- [play-ebean 3.0.1](https://github.com/playframework/play-ebean/blob/3.0.1/sbt-play-ebean/src/main/scala/play/ebean/sbt/PlayEbean.scala#L107-L148) used by [play-java-ebean-example branch 2.5.x](https://github.com/playframework/play-java-ebean-example/tree/2.5.x)
- [play-ebean 4.1.0](https://github.com/playframework/play-ebean/blob/4.1.0/sbt-play-ebean/src/main/scala-sbt-1.0/sbt/PlayEbean.scala#L120-L148) used by [play-java-ebean-example branch 2.6.x](https://github.com/playframework/play-java-ebean-example/tree/2.6.x)
```scala
  private def configuredEbeanModels = Def.task {
    import collection.JavaConverters._
    import java.util.{ Map => JMap, List => JList }

    // Creates a classloader with all the dependencies and all the resources, from there we can use the play ebean
    // code to load the config as it would be loaded in production
    def withClassLoader[T](block: ClassLoader => T): T = {
      val classpath = unmanagedResourceDirectories.value.map(_.toURI.toURL) ++ dependencyClasspath.value.map(_.data.toURI.toURL)
      val classLoader = new URLClassLoader(classpath.toArray, null)
      try {
        block(classLoader)
      } catch {
        case e: Exception =>
          // Since we're about to close the classloader, we can't risk any classloading that the thrown exception may
          // do when we later interogate it, so instead we create a new exception here, with the old exceptions message
          // and stack trace
          def clone(t: Throwable): RuntimeException = {
            val cloned = new RuntimeException(s"${t.getClass.getName}: ${t.getMessage}")
            cloned.setStackTrace(t.getStackTrace)
            if (t.getCause != null) {
              cloned.initCause(clone(t.getCause))
            }
            cloned
          }
          throw clone(e)
      } finally {
        classLoader.close()
      }
    }

    withClassLoader { classLoader =>
      val configLoader = classLoader.loadClass("play.db.ebean.ModelsConfigLoader").
        asSubclass(classOf[java.util.function.Function[ClassLoader, JMap[String, JList[String]]]])
      val config = configLoader.newInstance().apply(classLoader)

      if (config.isEmpty) {
        Seq("models.*")
      } else {
        config.asScala.flatMap(_._2.asScala).toSeq.distinct
      }
    }
  }
```

Because implementation differences are significant, the logic will be moved from `ebean-enhance` goal to providers.

There will be one difference between SBT and Maven implementations done on purpose.
In Play! versions 2.1.x - 2.3.x (SBT version) configuration was loaded from `conf/application.conf` file (if any of `config.resource` and `config.file` system properties wasn't specified).
Here it will be loaded from `target/classes/application.conf` because all project resources, regardless of their directories are copied to `target/classes` directory before code compilation and enhancement, so there is no need to search `application.conf` file in all resource directories.

Fixes #150
Closes #152
