### PR TITLE
Improve project build while running in development mode

### DIFF
--- a/play2-maven-plugin/src/main/java/com/google/code/play2/plugin/MavenPlay2BuilderRunnable.java
+++ b/play2-maven-plugin/src/main/java/com/google/code/play2/plugin/MavenPlay2BuilderRunnable.java
@@ -1,0 +1,23 @@
+package com.google.code.play2.plugin;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.LifecycleExecutor;
+
+public class MavenPlay2BuilderRunnable implements Runnable
+{
+    private LifecycleExecutor lifecycleExecutor;
+
+    private MavenSession session;
+
+    public MavenPlay2BuilderRunnable( LifecycleExecutor lifecycleExecutor, MavenSession session )
+    {
+        this.lifecycleExecutor = lifecycleExecutor;
+        this.session = session;
+    }
+
+    @Override
+    public void run()
+    {
+        lifecycleExecutor.execute( session );
+    }
+}


### PR DESCRIPTION
Improvements:
- run Maven build in separate thread,
- when reloading multi-module project after database evolutions were applied, all modules must be rebuild, not only the ones with modified files (tested on `play-java-ebean-example` project)
- better handle RuntimeExceptions thrown by the build (tested on `play-java-ebean-example` project with `play-ebean`' dependency removed)