### PR TITLE
As of Play 2.9 "build-link" now has the "play-" prefix

### DIFF
--- a/play2-providers/play2-provider-play28/pom.xml
+++ b/play2-providers/play2-provider-play28/pom.xml
@@ -67,7 +67,7 @@ under the License.
 
         <dependency>
             <groupId>com.typesafe.play</groupId>
-            <artifactId>build-link</artifactId>
+            <artifactId>play-build-link</artifactId>
             <version>${play2.version}</version>
         </dependency>
 


### PR DESCRIPTION
Do not merge this pull request, it is for Play 2.9 which is not released yet but will be soon.
(Also this PR would change the file `play2-providers/play2-provider-play28/pom.xml`, but would have to go into `play2-providers/play2-provider-play29/pom.xml` instead probably).

This is just a reminder that when you upgrade to 2.9 that the `build-link` artifact was renamed.